### PR TITLE
Update .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,4 +19,4 @@ ports:
 
 vscode:
   extensions:
-    - azuretools.vscode-docker
+    - ms-azuretools.vscode-docker


### PR DESCRIPTION
Fixes #1,
The id of  `azuretools.vscode-docker` is now  `ms-azuretools.vscode-docker`  is Open VSX.