### PR TITLE
Update MTU size to align value with the veth size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,3 +48,6 @@ services:
 networks:
   elastic:
     driver: bridge
+    # default MTU size in docker-compose is 1500
+    driver_opts:
+      com.docker.network.driver.mtu: 1440


### PR DESCRIPTION
## Description

Due to the removal of slirp4netns, we need to align the default value to the one in gitpod.io

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update MTU size to align value with the veth size
```
